### PR TITLE
Optimize `fbmkr` for large samples with parallel computing and better `sel` handling

### DIFF
--- a/R/CompPostmeanHnew_wasp.R
+++ b/R/CompPostmeanHnew_wasp.R
@@ -12,10 +12,33 @@ postmeanhnew_wasp<-function(fit,X,y,Z, Znew = NULL, sel = NULL) {
   }
 
   len <- length(fit$lambda)
-  sigsq.eps <- mean(fit$sigsq.eps[(len/2+1):len])
-  r <-colMeans(fit$r[(len/2+1):len,])
-  beta <- colMeans(as.matrix(fit$beta[(len/2+1):len,]))
-  lambda <-mean(fit$lambda[(len/2+1):len])
+  # sigsq.eps <- mean(fit$sigsq.eps[(len/2+1):len])
+	# r <-colMeans(fit$r[(len/2+1):len,])
+	# beta <- colMeans(as.matrix(fit$beta[(len/2+1):len,]))
+	# lambda <-mean(fit$lambda[(len/2+1):len])
+
+	## ---------- JUDGE `sel' ----------
+	if (is.null(sel)) {
+		## default：select the right half of samples
+		sel <- (len %/% 2 + 1):len
+	} else if (length(sel) == 1 && sel > 0 && sel < 1) {
+		## fraction -> index
+		sel <- (floor(len * sel) + 1):len
+	} else if (is.logical(sel) && length(sel) == len) {
+		## logical -> index
+		sel <- which(sel)
+	} else if (is.numeric(sel)) {
+		## index: boundary check
+		if (any(sel < 1 | sel > len)) stop("'sel' index out of bounds.")
+	} else {
+		stop("'sel' must be NULL, a proportion in (0,1), a logical vector of length nIter, or an index vector.")
+	}
+	
+	## ---------- SELECT SAMPLES ----------
+	sigsq.eps <- mean(fit$sigsq.eps[sel])
+	r          <- colMeans(fit$r[sel, , drop = FALSE])
+	beta       <- colMeans(as.matrix(fit$beta[sel, , drop = FALSE]))
+	lambda     <- mean(fit$lambda[sel])
 
   K<-makeKpart_wasp(r, Z)
   V <- diag(1, nrow(Z), nrow(Z)) + lambda*K

--- a/R/CompRisk_wasp.R
+++ b/R/CompRisk_wasp.R
@@ -36,7 +36,7 @@ OverallRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
 	# if(is.null(n.cores)){n.cores <- ceiling(parallel::detectCores()/2)}
 	# my.cluster <- parallel::makeCluster(n.cores)
 	# doParallel::registerDoParallel(cl = my.cluster)
-	# ---- PARALLEL SEPUP ----
+	# ---- PARALLELIZATION SEPUP ----
 	if (parallel) {
 		if (is.null(n_cores)) {
 			n_cores <- ceiling(parallel::detectCores()/2)
@@ -54,7 +54,7 @@ OverallRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
 		
 		doParallel::registerDoParallel(cl)
 		
-		message("Parallel tasks been started: ", foreach::getDoParName(),
+		message("Parallelization started: ", foreach::getDoParName(),
 										", workers = ", foreach::getDoParWorkers())
 	}
 
@@ -76,11 +76,12 @@ OverallRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
     df <- data.frame(quantile = qs, df)
     return( df)
   }
+
+  risks.overall_overall <- risks.overall[[1]]
+				   
   # stopCluster(cl = my.cluster)
   if (parallel) stopCluster(cl)
 
-
-  risks.overall_overall<-risks.overall[[1]]
   if(n_subset>1){##median combination of normal distributions is taking average of their mean and std
     for (i in 2:n_subset){
       risks.overall_overall$est<-risks.overall_overall$est+risks.overall[[i]]$est
@@ -209,6 +210,7 @@ SingVarRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
 
 
 }
+
 
 
 

--- a/R/CompRisk_wasp.R
+++ b/R/CompRisk_wasp.R
@@ -48,8 +48,8 @@ OverallRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
 		
 		cl <- parallel::makeCluster(n_cores)
 		on.exit({
-			parallel::stopCluster(cl)
-			doParallel::registerDoSEQ()
+		  parallel::stopCluster(cl)   # 1. Shut down the cluster and free its system resources
+		  foreach::registerDoSEQ()    # 2. Reset the foreach backend to sequential execution
 		}, add = TRUE)
 		
 		doParallel::registerDoParallel(cl)
@@ -209,5 +209,6 @@ SingVarRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
 
 
 }
+
 
 

--- a/R/CompRisk_wasp.R
+++ b/R/CompRisk_wasp.R
@@ -161,8 +161,8 @@ SingVarRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
 		
 		cl <- parallel::makeCluster(n_cores)   # default: PSOCK
 		on.exit({
-			parallel::stopCluster(cl)
-			doParallel::registerDoSEQ()         # stop parallelization
+			parallel::stopCluster(cl)   # 1. Shut down the cluster and free its system resources
+			foreach::registerDoSEQ()    # 2. Reset the foreach backend to sequential execution
 		}, add = TRUE)
 		
 		doParallel::registerDoParallel(cl)
@@ -210,6 +210,7 @@ SingVarRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
 
 
 }
+
 
 
 

--- a/R/CompRisk_wasp.R
+++ b/R/CompRisk_wasp.R
@@ -80,7 +80,7 @@ OverallRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
   risks.overall_overall <- risks.overall[[1]]
 				   
   # stopCluster(cl = my.cluster)
-  if (parallel) stopCluster(cl)
+  # if (parallel) stopCluster(cl)
 
   if(n_subset>1){##median combination of normal distributions is taking average of their mean and std
     for (i in 2:n_subset){
@@ -210,6 +210,7 @@ SingVarRiskSummaries_wasp <- function(fit, y = NULL, Z = NULL, X = NULL, paralle
 
 
 }
+
 
 
 

--- a/R/K.fit_BKMR_wasp.R
+++ b/R/K.fit_BKMR_wasp.R
@@ -341,8 +341,8 @@ kmbayes_Wasp<-function(Z,X,y,n_subset,n_samp=200, iter=1000, parallel=FALSE, n_c
 		
 		cl <- parallel::makeCluster(n_cores)   # default: PSOCK
 		on.exit({
-			parallel::stopCluster(cl)
-			doParallel::registerDoSEQ()         # stop parallelation
+		  parallel::stopCluster(cl)   # ① 关闭并释放 cluster 占用的进程/线程等系统资源
+		  foreach::registerDoSEQ()    # ② 把 foreach 的执行后端恢复成默认的串行模式
 		}, add = TRUE)
 		
 		doParallel::registerDoParallel(cl)

--- a/R/K.fit_BKMR_wasp.R
+++ b/R/K.fit_BKMR_wasp.R
@@ -341,9 +341,10 @@ kmbayes_Wasp<-function(Z,X,y,n_subset,n_samp=200, iter=1000, parallel=FALSE, n_c
 		
 		cl <- parallel::makeCluster(n_cores)   # default: PSOCK
 		on.exit({
-		  parallel::stopCluster(cl)   # ① 关闭并释放 cluster 占用的进程/线程等系统资源
-		  foreach::registerDoSEQ()    # ② 把 foreach 的执行后端恢复成默认的串行模式
+		  parallel::stopCluster(cl)   # 1. Shut down the cluster and free its system resources
+		  foreach::registerDoSEQ()    # 2. Reset the foreach backend to sequential execution
 		}, add = TRUE)
+
 		
 		doParallel::registerDoParallel(cl)
 		
@@ -594,4 +595,5 @@ skmbayes <- function(Z,X,y,n_subset=1,n_samp=200, iter=1000, parallel=FALSE, n_c
 
 
   }
+
 

--- a/R/PredictorResponseFunctions.R
+++ b/R/PredictorResponseFunctions.R
@@ -77,8 +77,8 @@ PredictorResponseUnivar <- function(fit, y = NULL, Z = NULL, X = NULL, parallel 
 		
 		cl <- parallel::makeCluster(n_cores)
 		on.exit({
-			parallel::stopCluster(cl)
-			doParallel::registerDoSEQ()
+		  parallel::stopCluster(cl)   # 1. Shut down the cluster and free its system resources
+		  foreach::registerDoSEQ()    # 2. Reset the foreach backend to sequential execution
 		}, add = TRUE)
 		
 		doParallel::registerDoParallel(cl)
@@ -215,8 +215,8 @@ PredictorResponseBivar <- function(fit, y = NULL, Z = NULL, X = NULL, parallel =
 		
 		cl <- parallel::makeCluster(n_cores)
 		on.exit({
-			parallel::stopCluster(cl)
-			doParallel::registerDoSEQ()
+		  parallel::stopCluster(cl)   # 1. Shut down the cluster and free its system resources
+		  foreach::registerDoSEQ()    # 2. Reset the foreach backend to sequential execution
 		}, add = TRUE)
 		
 		doParallel::registerDoParallel(cl)
@@ -369,3 +369,4 @@ PredictorResponseBivarLevels <- function(pred.resp.df, Z = NULL, qs = c(0.25, 0.
     dplyr::arrange_(~variable1, ~variable2)
   df
 }
+


### PR DESCRIPTION
Based on practical experience with the `fbmkr` package under large datasets, the following improvements have been implemented (by @HaoPAN-Flora):

1. Added `parallel` and `n_cores` arguments to support parallel computation; Updated documentation (`@param`) accordingly.
2. When `parallel = TRUE`, the parallel execution flow has been restructured  for better clarity and control.
3. Added a more rigorous check on the `sel` argument in `PredictorResponseFunctions.R`, enabling practical post-selection capabilities on the MCMC chain.
